### PR TITLE
Make it work for YouTube

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var update = function(speed){
     }
 
     active.playbackRate = speed;
-    rate.innerHTML = speed;
+    rate.textContent = speed;
 };
 
 var setVideo = function(v){
@@ -124,17 +124,17 @@ buttons.appendChild(b_three);
 buttons.appendChild(b_end);
 buttons.style.display = 'flex';
 buttons.style.justifyContent = 'space-between';
-b_half.innerHTML = '&frac12;x';
+b_half.textContent = '½x';
 b_half.href = '#';
-b_one.innerHTML = '1x';
+b_one.textContent = '1x';
 b_one.href = '#';
-b_two.innerHTML = '2x';
+b_two.textContent = '2x';
 b_two.href = '#';
-b_three.innerHTML = '3x';
+b_three.textContent = '3x';
 b_three.href = '#';
-b_beg.innerHTML = '<<';
+b_beg.textContent = '<<';
 b_beg.href = '#';
-b_end.innerHTML = '>>';
+b_end.textContent = '>>';
 b_end.href = '#';
 range.type = 'range';
 range.min = '.25';


### PR DESCRIPTION
The bookmarklet's popup never shows up because it fails on .innerHTML assignation.

```txt
Uncaught TypeError: Failed to set the 'innerHTML' property on 'Element': This document requires 'TrustedHTML' assignment.
    at update (<anonymous>:19:20)
    at setVideo (<anonymous>:24:5)
    at <anonymous>:76:5
    at <anonymous>:173:4
```

From ChatGPT:

> The error you're encountering is due to YouTube's increased security restrictions around handling HTML. In particular, the TrustedHTML assignment error stems from YouTube requiring certain elements to use TrustedHTML for innerHTML assignment, likely to prevent Cross-Site Scripting (XSS) attacks.
>
> To bypass this, you can set the text content with textContent instead of innerHTML. textContent does not parse HTML, so it’s safer and doesn’t trigger YouTube’s security requirements.

After replacing these, it works like a charm.

Also, because setting textContent won't properly parse HTML entities, we also replace the '&frac12;x' fraction for its Unicode equivalent.

Aside from that, thank you for the bookmarklet! It's very handy to watch game playthroughs with repetitive battles, or sections of courses that are a slog. :purple_heart: 